### PR TITLE
Add global variable IntervalPageCompleted

### DIFF
--- a/Scripts/jquery.SplashScreen.js
+++ b/Scripts/jquery.SplashScreen.js
@@ -72,7 +72,8 @@
                     }
 
                     if (c === totalImages) {
-                        setTimeout(function () { return pageLoadCompleted() }, settings.timeOut);
+                    	var element = document.getElementById(settings.id);
+                        element.IntervalPageCompleted = setTimeout(function () { return pageLoadCompleted() }, settings.timeOut);
                     }
                 }
 


### PR DESCRIPTION
In order to manually clear the splashscreen after a click for example, I add a global variable in order to use clearTimeout to delete the event.
Use like:
var element = document.getElementById('splashscreen');
clearTimeout(element.IntervalPageCompleted);
